### PR TITLE
Ion Chamber Integration

### DIFF
--- a/startup/34-quadem.py
+++ b/startup/34-quadem.py
@@ -108,21 +108,21 @@ quadem1.Iy.name = 'Iy'
 class BMMDualEM(QuadEM):
     _default_read_attrs = ['Ia',
                            'Ib']
-    port_name = Cpt(Signal, value='EM180')
-    conf = Cpt(QuadEMPort, port_name='EM180')
-    em_range  = Cpt(EpicsSignalWithRBV, 'Range', string=True)
+    port_name = Cpt(Signal, value='NSLS2_IC')
+    conf = Cpt(QuadEMPort, port_name='NSLS2_IC')
+    em_range = Cpt(EpicsSignalWithRBV, 'Range', string=True)
     Ia = Cpt(Nanoize, derived_from='current1.mean_value')
     Ib = Cpt(Nanoize, derived_from='current2.mean_value')
-    state  = Cpt(EpicsSignal, 'Acquire')
+    state = Cpt(EpicsSignal, 'Acquire')
 
     calibration_mode = Cpt(EpicsSignal, 'CalibrationMode')
     copy_adc_offsets = Cpt(EpicsSignal, 'CopyADCOffsets.PROC')
-    compute_current_offset1  = Cpt(EpicsSignal, 'ComputeCurrentOffset1.PROC')
-    compute_current_offset2  = Cpt(EpicsSignal, 'ComputeCurrentOffset2.PROC')
+    compute_current_offset1 = Cpt(EpicsSignal, 'ComputeCurrentOffset1.PROC')
+    compute_current_offset2 = Cpt(EpicsSignal, 'ComputeCurrentOffset2.PROC')
 
     sigma1 = Cpt(EpicsSignal, 'Current1:Sigma_RBV')
     sigma2 = Cpt(EpicsSignal, 'Current1:Sigma_RBV')
-    
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
Currently the only change is using `NSLS2_IC` instead of `EM180` as the `port_name`.

After testing and discussing with @tacaswell, this seems like the only change required to resolve this error message:
```
RuntimeError: The asyn ports ['NSLS2_IC'] are used by plugins that ophyd is aware of but the source plugin is not.  Please reconfigure your device to include the source plugin or reconfigure to not use these ports.
```
After making this change, I was able to `stage()` the device successfully.

@bruceravel: 
Since you said you weren't in a hurry to get this fixed, and it's a good opportunity for me to learn about the inner workings of QuadEM/AreaDetector, I'm still digging deeper in the code to understand it better and see if anything else can be improved. 

Did you have a wishlist of improvements beyond getting rid of this error? You mentioned users were coming on Friday? Should I maybe bring it back to the beamline today or tomorrow, so we can see if it works and/or if anything else breaks?