### PR TITLE
CI: use collection-2020-2.0rc7-1 conda env for online tests

### DIFF
--- a/.ci/bl-specific.sh
+++ b/.ci/bl-specific.sh
@@ -2,4 +2,5 @@
 
 # cp -v <...> ~/.ipython/profile_${TEST_PROFILE}/
 
-conda install -y -c ${CONDA_CHANNEL_NAME} 06-bm-bmm-collection
+# The beamline-specific metapackages are not used since 2020-2.0 deployment.
+# conda install -y -c ${CONDA_CHANNEL_NAME} 06-bm-bmm-collection

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ resources:
     - repository: templates
       type: github
       name: NSLS-II/profile-collection-ci
-      # ref: refs/heads/<branch-name>  # for future testings on a branch of NSLS-II/profile-collection-ci
+      ref: refs/heads/collection-2020-2.0rc7-1
       endpoint: github
 
 jobs:

--- a/startup/BMM/xspress3.py
+++ b/startup/BMM/xspress3.py
@@ -257,7 +257,8 @@ class BMMXspress3Detector(XspressTrigger, Xspress3Detector):
         
     def set_rois(self):
         config = configparser.ConfigParser()
-        config.read_file(open(os.path.join(os.getenv('HOME'), '.ipython', 'profile_collection', 'startup', 'rois.ini')))
+        startup_dir = get_ipython().profile_dir.startup_dir
+        config.read_file(open(os.path.join(startup_dir, 'rois.ini')))
         for i, el in enumerate(self.slots):
             if el is None:
                 continue


### PR DESCRIPTION
@bruceravel, it fixes the failing CI builds as there are new features used in the profile (implemented via #3).

