### PR TITLE
collection-2020-2.0rc9 for CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,7 +3,7 @@ resources:
     - repository: templates
       type: github
       name: NSLS-II/profile-collection-ci
-      ref: refs/heads/collection-2020-2.0rc7-1
+      ref: refs/heads/collection-2020-2.0rc9
       endpoint: github
 
 jobs:


### PR DESCRIPTION
This PR uses the updated conda environment that contain the `redis` package, so that it will make the CI test to pass.