### PR TITLE
CI: pip install missing bluesky-widgets package

### DIFF
--- a/.ci/bl-specific.sh
+++ b/.ci/bl-specific.sh
@@ -6,3 +6,5 @@ if [ "$CONDA_ENV_NAME" == "collection-2021-1.0" ]; then
     conda remove wxpython --force -y
 fi
 
+pip install -v git+https://github.com/bluesky/bluesky-widgets
+


### PR DESCRIPTION
There were some updates between #11 was opened and merged, which brought additional dependencies.
```py
Traceback (most recent call last):
  File "<ipython-input-1-19fca0ca65e8>", line 13, in <module>
    ip.parent._exec_file(f)
  File "/home/vsts/miniconda/envs/collection-2021-1.2/lib/python3.7/site-packages/IPython/core/shellapp.py", line 381, in _exec_file
    raise_exceptions=True)
  File "/home/vsts/miniconda/envs/collection-2021-1.2/lib/python3.7/site-packages/IPython/core/interactiveshell.py", line 2759, in safe_execfile
    self.compile if shell_futures else None)
  File "/home/vsts/miniconda/envs/collection-2021-1.2/lib/python3.7/site-packages/IPython/utils/py3compat.py", line 168, in execfile
    exec(compiler(f.read(), fname, 'exec'), glob, loc)
  File "/home/vsts/work/1/s/startup/90-bmm.py", line 216, in <module>
    from bluesky_widgets.utils.streaming import stream_documents_into_runs
ModuleNotFoundError: No module named 'bluesky_widgets'

[nslsii.ipython] ERROR : No module named 'bluesky_widgets'
Traceback (most recent call last):
  File "/home/vsts/miniconda/envs/collection-2021-1.2/lib/python3.7/site-packages/IPython/core/interactiveshell.py", line 3437, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-1-19fca0ca65e8>", line 13, in <module>
    ip.parent._exec_file(f)
  File "/home/vsts/miniconda/envs/collection-2021-1.2/lib/python3.7/site-packages/IPython/core/shellapp.py", line 381, in _exec_file
    raise_exceptions=True)
  File "/home/vsts/miniconda/envs/collection-2021-1.2/lib/python3.7/site-packages/IPython/core/interactiveshell.py", line 2759, in safe_execfile
    self.compile if shell_futures else None)
  File "/home/vsts/miniconda/envs/collection-2021-1.2/lib/python3.7/site-packages/IPython/utils/py3compat.py", line 168, in execfile
    exec(compiler(f.read(), fname, 'exec'), glob, loc)
  File "/home/vsts/work/1/s/startup/90-bmm.py", line 216, in <module>
    from bluesky_widgets.utils.streaming import stream_documents_into_runs
ModuleNotFoundError: No module named 'bluesky_widgets'
```
See the [CI log](https://dev.azure.com/nsls2/profile_collections/_build/results?buildId=1979&view=logs&j=01379a27-47fc-5e45-e3dd-439819cb52bf&t=7ed15aff-9b7d-5848-a770-25bbaaa714b9&l=893) for details.