### PR TITLE
Publish bluesky documents as Kafka messages

### DIFF
--- a/startup/00-base.py
+++ b/startup/00-base.py
@@ -1,7 +1,7 @@
 import nslsii
 ip = get_ipython()
 
-nslsii.configure_base(ip.user_ns, 'bmm', configure_logging=False)
+nslsii.configure_base(ip.user_ns, 'bmm', configure_logging=False, publish_documents_to_kafka=True)
 
 bec.disable_plots()
 bec.disable_baseline()


### PR DESCRIPTION
The PR sets `publish_documents_to_kafka=True` in 00-base.py.

It is also necessary to `export BLUESKY_KAFKA_BOOTSTRAP_SERVERS=kafka1.nsls2.bnl.gov:9092,...` so that bsui can find it.