### PR TITLE
🐆 Implement tiled `quality-of-service` for priority requests

### DIFF
--- a/startup/BMM/user_ns/base.py
+++ b/startup/BMM/user_ns/base.py
@@ -91,6 +91,7 @@ else:
 RE.unsubscribe(0)  # remove databroker, which was subscribed first by configure_base
 tiled_writing_client = from_uri(profile_configuration.get('services', 'tiled'),
                                 api_key=os.environ["TILED_BLUESKY_WRITING_API_KEY_BMM"])
+tiled_writing_client.context.http_client.headers['tiled-qos'] = 'acquisition'
 
 datum_docs_cache = deque()
 def create_datum_page_cb(name, doc):
@@ -172,6 +173,7 @@ if not is_re_worker_active():
     cprint('[cyan]Connecting to Tiled: bmm_catalog, db[/cyan]')
     from tiled.client import from_profile, from_uri
     bmm_catalog = from_profile('bmm')
+    bmm_catalog.context.http_client.headers['tiled-qos'] = 'acquisition'
     ##bmm_catalog = from_uri('https://tiled.nsls2.bnl.gov/api/v1/metadata/bmm/migration')
     db = Broker(bmm_catalog)
 

--- a/startup/consumer/consume_measurement.py
+++ b/startup/consumer/consume_measurement.py
@@ -10,6 +10,7 @@ import nslsii.kafka_utils
 
 from tiled.client import from_profile, from_uri
 bmm_catalog = from_profile('bmm')
+bmm_catalog.context.http_client.headers['tiled-qos'] = 'acquisition'
 #bmm_catalog = from_uri('https://tiled.nsls2.bnl.gov/api/v1/metadata/bmm/migration')
 
 import matplotlib.pyplot as plt

--- a/startup/consumer/file_manager.py
+++ b/startup/consumer/file_manager.py
@@ -22,6 +22,7 @@ import bmm_tools.tools.db
 
 from tiled.client import from_profile, from_uri
 bmm_catalog = from_profile('bmm')
+bmm_catalog.context.http_client.headers['tiled-qos'] = 'acquisition'
 #bmm_catalog = from_uri('https://tiled.nsls2.bnl.gov/api/v1/metadata/bmm/migration')
 bmm_tools.tools.db.bmm_catalog = bmm_catalog
 from bmm_tools.tools.db import file_resource


### PR DESCRIPTION
Tiled recently added a mechanism to ensure that critical path writing requests made during data acquisition go through, while other Prefect workflows that are not as tightly coupled to operations are put on a scheduled queue such that the Tiled servers will be less likely to become saturated / go down / become unavailable e.g.

Note that `bmm_catalog` _might only need to have it's headers set once but I'm doing it for each occurrence to be safe._